### PR TITLE
Send Slack messages using Incoming Webhooks app

### DIFF
--- a/SlackTransportFactory.php
+++ b/SlackTransportFactory.php
@@ -29,28 +29,27 @@ final class SlackTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
-        $accessToken = $this->getUser($dsn);
         $channel = $dsn->getOption('channel');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
-        
 
         if ('slack' === $scheme) {
+            $accessToken = $this->getUser($dsn);
             return (new SlackTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
         }
-        
+
         if ('slack+webhook' === $scheme) {
             $webhookPath = ltrim($dsn->getPath(), '/');
             $username = $dsn->getOption('username');
 
             return (new SlackWebhookTransport($webhookPath, $channel, $username, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
         }
-        
+
         throw new UnsupportedSchemeException($dsn, 'slack', $this->getSupportedSchemes());
     }
 
     protected function getSupportedSchemes(): array
     {
-        return ['slack'];
+        return ['slack', 'slack+webhook'];
     }
 }

--- a/SlackTransportFactory.php
+++ b/SlackTransportFactory.php
@@ -33,11 +33,19 @@ final class SlackTransportFactory extends AbstractTransportFactory
         $channel = $dsn->getOption('channel');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
+        
 
         if ('slack' === $scheme) {
             return (new SlackTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
         }
+        
+        if ('slack+webhook' === $scheme) {
+            $webhookPath = ltrim($dsn->getPath(), '/');
+            $username = $dsn->getOption('username');
 
+            return (new SlackWebhookTransport($webhookPath, $channel, $username, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        }
+        
         throw new UnsupportedSchemeException($dsn, 'slack', $this->getSupportedSchemes());
     }
 

--- a/SlackWebhookTransport.php
+++ b/SlackWebhookTransport.php
@@ -49,7 +49,7 @@ final class SlackWebhookTransport extends AbstractTransport
 
         parent::__construct($client, $dispatcher);
     }
-    
+
     public function __toString(): string
     {
         return sprintf(
@@ -85,32 +85,25 @@ final class SlackWebhookTransport extends AbstractTransport
         }
 
         $options = $opts ? $opts->toArray() : [];
-        $options['token'] = $this->accessToken;
         if (!isset($options['channel'])) {
             $options['channel'] = $message->getRecipientId() ?: $this->channel;
         }
         $options['username'] = $options['username'] ?? $this->username;
         $options['text'] = $message->getSubject();
+
         $response = $this->client->request(
-            'POST', 
+            'POST',
             sprintf(
                 '%s://%s/%s',
                 'https',
                 $this->getEndpoint(),
                 $this->webhookPath
-            ), 
-            [
-                'body' => array_filter($options),
-            ]
+            ),
+            ['json' => array_filter($options)]
         );
 
         if (200 !== $response->getStatusCode()) {
             throw new TransportException(sprintf('Unable to post the Slack message: %s.', $response->getContent(false)), $response);
-        }
-
-        $result = $response->toArray(false);
-        if (!$result['ok']) {
-            throw new TransportException(sprintf('Unable to post the Slack message: %s.', $result['error']), $response);
         }
     }
 }

--- a/SlackWebhookTransport.php
+++ b/SlackWebhookTransport.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Slack;
+
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @internal
+ *
+ * @experimental in 5.0
+ */
+final class SlackWebhookTransport extends AbstractTransport
+{
+    protected const HOST = 'hooks.slack.com';
+
+    protected $client;
+    private $webhookPath;
+    private $channel;
+    private $username;
+
+    public function __construct(
+        string $webhookPath,
+        string $channel,
+        string $username,
+        HttpClientInterface $client = null,
+        EventDispatcherInterface $dispatcher = null
+    ) {
+        $this->client = $client;
+        $this->webhookPath = $webhookPath;
+        $this->channel = $channel;
+        $this->username = $username;
+
+        parent::__construct($client, $dispatcher);
+    }
+    
+    public function __toString(): string
+    {
+        return sprintf(
+            '%s://%s/%s?channel=%s&username=%s&',
+            SlackWebhookTransportFactory::SCHEME,
+            $this->getEndpoint(),
+            $this->webhookPath,
+            $this->channel,
+            $this->username
+        );
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof ChatMessage && (null === $message->getOptions() || $message->getOptions() instanceof SlackOptions);
+    }
+
+    /**
+     * Sending messages using Incoming Webhooks
+     * @see https://api.slack.com/messaging/webhooks
+     */
+    protected function doSend(MessageInterface $message): void
+    {
+        if (!$message instanceof ChatMessage) {
+            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, \get_class($message)));
+        }
+        if ($message->getOptions() && !$message->getOptions() instanceof SlackOptions) {
+            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, SlackOptions::class));
+        }
+
+        if (!($opts = $message->getOptions()) && $notification = $message->getNotification()) {
+            $opts = SlackOptions::fromNotification($notification);
+        }
+
+        $options = $opts ? $opts->toArray() : [];
+        $options['token'] = $this->accessToken;
+        if (!isset($options['channel'])) {
+            $options['channel'] = $message->getRecipientId() ?: $this->channel;
+        }
+        $options['username'] = $options['username'] ?? $this->username;
+        $options['text'] = $message->getSubject();
+        $response = $this->client->request(
+            'POST', 
+            sprintf(
+                '%s://%s/%s',
+                'https',
+                $this->getEndpoint(),
+                $this->webhookPath
+            ), 
+            [
+                'body' => array_filter($options),
+            ]
+        );
+
+        if (200 !== $response->getStatusCode()) {
+            throw new TransportException(sprintf('Unable to post the Slack message: %s.', $response->getContent(false)), $response);
+        }
+
+        $result = $response->toArray(false);
+        if (!$result['ok']) {
+            throw new TransportException(sprintf('Unable to post the Slack message: %s.', $result['error']), $response);
+        }
+    }
+}


### PR DESCRIPTION
> Legacy tokens are a deprecated method of generating tokens for testing and development.

Usage:
`slack+webhook://hooks.slack.com/services/xxx/xxx/xxx?channel=gitlab&username=test`
